### PR TITLE
minor edit on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,10 @@ A stable, known working version of the [Substrate Node Template](https://github.
     ```sh
     ./scripts/init.sh
     cargo build --release
-    cargo run --release -- --dev
-    ```
-
-    The above process may take 30 minuites or so, depending on your hardware. This should start your node, and you should see blocks being created
-
-    If you have not modified the source code since last compilation, or just want to directly run the node,
-
-    ```sh
     ./target/release/node-template --dev
     ```
+
+    The above process may take 30 minuites or so, depending on your hardware. This should start your node, and you should see blocks being created.
 
 * Go into the `substrate-front-end-template` folder and run:
 
@@ -41,7 +35,7 @@ A stable, known working version of the [Substrate Node Template](https://github.
     yarn start
     ```
 
-    This should start a web server on `localhost:3000` where you can interact with your node
+    This should start a web server on `localhost:3000` where you can interact with your node.
 
 * Go into the `substrate-module-template` folder:
     * Read `HOWTO.md`

--- a/README.md
+++ b/README.md
@@ -19,15 +19,29 @@ A stable, known working version of the [Substrate Node Template](https://github.
     * Windows users need to follow [instructions here](https://github.com/paritytech/substrate#61-hacking-on-substrate) instead
 
 * Go into the `substrate-node-template` folder and run:
-    * `./scripts/init.sh`
-    * `cargo build --release`
-    * `cargo run --release -- --dev`
-    * This should start your node, and you should see blocks being created
+
+    ```sh
+    ./scripts/init.sh
+    cargo build --release
+    cargo run --release -- --dev
+    ```
+
+    The above process may take 30 minuites or so, depending on your hardware. This should start your node, and you should see blocks being created
+
+    If you have not modified the source code since last compilation, or just want to directly run the node,
+
+    ```sh
+    ./target/release/node-template --dev
+    ```
 
 * Go into the `substrate-front-end-template` folder and run:
-    * `yarn install`
-    * `yarn start`
-    * This should start a web server on `localhost:3000` where you can interact with your node
+
+    ```sh
+    yarn install
+    yarn start
+    ```
+
+    This should start a web server on `localhost:3000` where you can interact with your node
 
 * Go into the `substrate-module-template` folder:
     * Read `HOWTO.md`
@@ -40,7 +54,7 @@ A stable, known working version of the [Substrate Node Template](https://github.
 
 The `substrate-module-template` is a template where you can start building your own runtime module as it's own independent crate.
 
-This is an alternative from writing your module in `substrate-node-template/runtime/src/template.rs`, where you would not be able to easily share your runtime module after your are done. We recommend development in the `substrate-module-template` if you want to allow others to include your runtime module into their Substrate node. 
+This is an alternative from writing your module in `substrate-node-template/runtime/src/template.rs`, where you would not be able to easily share your runtime module after your are done. We recommend development in the `substrate-module-template` if you want to allow others to include your runtime module into their Substrate node.
 
 Instructions for using the `substrate-module-template` are included with the project.
 


### PR DESCRIPTION
Minor update on README and prefer to keep the cmd `./target/release/node-template`.

Wonder if this happen to you, that I didn't change the node src code, but running `cargo run --release -- --dev` still recompile, and then take 5 mins to start the node. On the other hand, using command `./target/release/node-template` just run the node. 