### PR TITLE
Freezing rustc versions.

### DIFF
--- a/substrate-node-template/runtime/wasm/build.sh
+++ b/substrate-node-template/runtime/wasm/build.sh
@@ -4,7 +4,7 @@ set -e
 if cargo --version | grep -q "nightly"; then
 	CARGO_CMD="cargo"
 else
-	CARGO_CMD="cargo +nightly"
+	CARGO_CMD="cargo +nightly-2020-07-10"
 fi
 CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release
 for i in node_template_runtime_wasm

--- a/substrate-node-template/scripts/init.sh
+++ b/substrate-node-template/scripts/init.sh
@@ -5,11 +5,12 @@ set -e
 echo "*** Initializing WASM build environment"
 
 if [ -z $CI_PROJECT_NAME ] ; then
-   rustup update nightly
-   rustup update stable
+   rustup update nightly-2020-07-10
+   rustup update 1.45.0
+   rustup default 1.45.0
 fi
 
-rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup target add wasm32-unknown-unknown --toolchain nightly-2020-07-10
 
 # Install wasm-gc. It's useful for stripping slimming down wasm binaries.
 command -v wasm-gc || \


### PR DESCRIPTION
I was able to run the `substrate-collectables-workshop` initial setup ("Running a Custom Node"):
```
cd substratekitties
./scripts/init.sh
./scripts/build.sh
cargo build --release
```

Using the followings rustc versions, in an Ubuntu 20.04 Docker container:
```
# rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /root/.rustup

installed toolchains
--------------------

stable-x86_64-unknown-linux-gnu
nightly-2020-07-10-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu
1.45.0-x86_64-unknown-linux-gnu (default)

active toolchain
----------------

1.45.0-x86_64-unknown-linux-gnu (default)
rustc 1.45.0 (5c1f21c3b 2020-07-13)
```